### PR TITLE
Remove misleading line about postback in js

### DIFF
--- a/help/sdk-implement/setup/set-up-chromecast.md
+++ b/help/sdk-implement/setup/set-up-chromecast.md
@@ -132,6 +132,3 @@ Chromecast SDK 2.x for Experience Cloud Solutions lets you measure Chromecast ap
    | `getMarketingCloudID()` | Retrieves the Experience Cloud Visitor ID from the Visitor ID service.  <br/><br/>`ADBMobile.visitor.getMarketingCloudID();` |
    | `syncIdentifiers()` | With the Experience Cloud Visitor ID, you can set additional customer IDs that can be associated with each visitor. The Visitor API accepts multiple customer IDs for the same visitor and a customer type identifier to separate the scope of the different customer IDs. This method corresponds to `setCustomerIDs()` in the JavaScript library.  For example: <br/><br/>`var identifiers = {}; <br/><br/>identifiers["idType"] = "idValue"; <br/><br/>ADBMobile.visitor.syncIdentifiers(identifiers);` |
 
-
-   **Postbacks -** For more information about configuring postbacks, see [Configure Postbacks.](https://marketing.adobe.com/resources/help/en_US/mobile/signals_.html) 
-


### PR DESCRIPTION
Postbacks are only supported for Android and iOS through mobile services, since mobile services updates a configuration file which is not available for the javascript.