### PR TITLE
Fix Type for Schemas Request

### DIFF
--- a/help/media-collection-api/mc-api-ref/mc-api-json-validation.md
+++ b/help/media-collection-api/mc-api-ref/mc-api-json-validation.md
@@ -10,7 +10,7 @@ uuid: 7c9d5ce4-f5d2-4129-900e-4d02800907d1
 The Media Analytics back-end validates the request parameters for each event type using JSON validation schemas. These schemas are available to you, and serve as the current authority on parameter types used in the MA API.
 
 ```
-POST
+GET
 https://{uri}/api/v1/schemas/{event-type}
 ```
 


### PR DESCRIPTION
As currently written, a POST request to the schemas endpoint returns a 405 - not allowed. In order to return the schema for the event, one needs to use a GET request.