### PR TITLE
Incorrect event description for ad complete.

### DIFF
--- a/help/media-collection-api/mc-api-ref/mc-api-event-types.md
+++ b/help/media-collection-api/mc-api-ref/mc-api-event-types.md
@@ -44,7 +44,7 @@ Signals the start of an ad
 
 ## adComplete
 
-Signals the completion of an ad break
+Signals the completion of an ad
 
 ## adSkip
 


### PR DESCRIPTION
Update the description of ad complete to more accurately describe the event.