### PR TITLE
typo to sample code

### DIFF
--- a/help/sdk-implement/sdk-to-launch/sdk-to-launch-migration-platforms/sdk-to-launch-migration-android.md
+++ b/help/sdk-implement/sdk-to-launch/sdk-to-launch-migration-platforms/sdk-to-launch-migration-android.md
@@ -230,7 +230,7 @@ is a change in the quality metrics.
    mediaMetadata.put("isUserLoggedIn", "false");
    mediaMetadata.put("tvStation", "Sample TV Station");
    
-   tracker.trackSessionStart(mediaInfo, mediaMetadata);
+   tracker.trackSessionStart(mediaObject, mediaMetadata);
    ```
 
 * Standard Ad Metadata:


### PR DESCRIPTION
Appears this is from the standalone SDK sample code - var name has changed in new Launch sample code